### PR TITLE
feat: add compound button variant

### DIFF
--- a/components/borrow-form.tsx
+++ b/components/borrow-form.tsx
@@ -149,7 +149,7 @@ export function BorrowForm() {
               <Button
                 variant="ghost"
                 size="sm"
-                className="absolute right-1 top-1 h-7 text-xs text-blue-400 hover:text-blue-300"
+                className="absolute right-1 top-1 h-7 text-xs"
                 onClick={handleMaxClick}
               >
                 MIN
@@ -166,7 +166,8 @@ export function BorrowForm() {
           </div>
 
           <Button
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+            variant="compound"
+            className="w-full"
             onClick={handleBorrow}
             disabled={!amount || Number.parseFloat(amount) <= 0 || isSubmitting}
           >

--- a/components/repay-form.tsx
+++ b/components/repay-form.tsx
@@ -142,7 +142,7 @@ export function RepayForm() {
               <Button
                 variant="ghost"
                 size="sm"
-                className="absolute right-1 top-1 h-7 text-xs text-blue-400 hover:text-blue-300"
+                className="absolute right-1 top-1 h-7 text-xs"
                 onClick={handleMaxClick}
               >
                 MAX
@@ -163,7 +163,8 @@ export function RepayForm() {
           </div>
 
           <Button
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+            variant="compound"
+            className="w-full"
             onClick={handleRepay}
             disabled={!amount || Number.parseFloat(amount) <= 0 || isSubmitting}
           >

--- a/components/supply-form.tsx
+++ b/components/supply-form.tsx
@@ -182,12 +182,12 @@ export function SupplyForm() {
 								onChange={(e) => setAmount(e.target.value)}
 								className="bg-[#252836] border-[#2a2d36] pr-16"
 							/>
-							<Button
-								variant="ghost"
-								size="sm"
-								className="absolute right-1 top-1 h-7 text-xs text-blue-400 hover:text-blue-300"
-								onClick={handleMaxClick}
-							>
+                                                        <Button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                className="absolute right-1 top-1 h-7 text-xs"
+                                                                onClick={handleMaxClick}
+                                                        >
 								MAX
 							</Button>
 						</div>
@@ -201,11 +201,12 @@ export function SupplyForm() {
 						</div>
 					</div>
 
-					<Button
-						className="w-full bg-blue-600 hover:bg-blue-700 text-white"
-						onClick={handleSupply}
-						disabled={!isConnected || isSubmitting || !amount || Number.parseFloat(amount) <= 0}
-					>
+                                        <Button
+                                                variant="compound"
+                                                className="w-full"
+                                                onClick={handleSupply}
+                                                disabled={!isConnected || isSubmitting || !amount || Number.parseFloat(amount) <= 0}
+                                        >
 						{isSubmitting ? (
 							<div className="flex items-center">
 								<div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,13 +10,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        compound:
+          "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/80",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-primary/60 bg-background text-primary hover:bg-primary/10 focus-visible:ring-primary/60",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-primary/10 hover:text-primary focus-visible:ring-primary/60",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/components/welcome-message.tsx
+++ b/components/welcome-message.tsx
@@ -53,7 +53,7 @@ export function WelcomeMessage() {
           </div>
         </CardContent>
         <CardFooter>
-          <Button className="w-full bg-blue-600 hover:bg-blue-700" onClick={() => setShowWelcome(false)}>
+          <Button variant="compound" className="w-full" onClick={() => setShowWelcome(false)}>
             Start Exploring
           </Button>
         </CardFooter>

--- a/components/withdraw-form.tsx
+++ b/components/withdraw-form.tsx
@@ -142,7 +142,7 @@ export function WithdrawForm() {
               <Button
                 variant="ghost"
                 size="sm"
-                className="absolute right-1 top-1 h-7 text-xs text-blue-400 hover:text-blue-300"
+                className="absolute right-1 top-1 h-7 text-xs"
                 onClick={handleMaxClick}
               >
                 MAX
@@ -159,7 +159,8 @@ export function WithdrawForm() {
           </div>
 
           <Button
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+            variant="compound"
+            className="w-full"
             onClick={handleWithdraw}
             disabled={!amount || Number.parseFloat(amount) <= 0 || isSubmitting}
           >


### PR DESCRIPTION
## Summary
- add a `compound` button variant alongside green-focused updates for the ghost and outline styles
- switch welcome and form CTA buttons to the new variant and rely on the refreshed accent styling

## Testing
- pnpm lint *(fails: requires interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c864287d848326a13c38f3bc1059f4